### PR TITLE
Add card split counts to generation.

### DIFF
--- a/assets/data_parser.py
+++ b/assets/data_parser.py
@@ -37,6 +37,7 @@ totalCollectorsTokensSpent = 0
 battlePassesBought = 0
 cardsOwned = 0
 cardSplits = 0
+cardSplitCounts = {}
 variants = 0
 avatarsOwned = 0
 titlesOwned = 0
@@ -192,12 +193,19 @@ def reload_file():
 		global cardsOwned
 		global cardSplits
 		global variants
+		global cardSplitCounts
 		allCardsData = data['ServerState']['Cards']
 		for card in allCardsData:
+			cardId = card['CardDefId']
+			if cardId not in cardSplitCounts:
+				cardSplitCounts[cardId] = 0
+
 			if 'ArtVariantDefId' not in card and 'Split' not in card:
 				cardsOwned += 1
 			if 'Split' in card:
 				cardSplits += 1
+				if "Custom" not in card:
+					cardSplitCounts[cardId] += 1
 			if 'ArtVariantDefId' in card and 'Split' not in card:
 				variants += 1
 
@@ -351,6 +359,11 @@ def get_CardsOwned():
 
 def get_CardSplits():
 	return cardSplits
+
+def get_CardSplitCounts():
+	sortedDict = dict(sorted(cardSplitCounts.items(), key=lambda item: item[1]))
+	flattenedList = [f"{cardId}: {splits}" for cardId, splits in sortedDict.items()]
+	return '\n'.join(flattenedList)
 
 def get_Variants():
 	return variants

--- a/assets/template.html
+++ b/assets/template.html
@@ -474,6 +474,16 @@ Only available for players that have reached Infinite.">
         <div class="row row2">
           <div class="column">
             <h1 center centered-element>
+              Split Count By Card
+            </h1>
+          </div>
+          <div class="column-cards">
+              <h1 style="width: 100%;">{{ cardSplitCounts }}</h1>
+          </div>
+        </div>
+        <div class="row row2">
+          <div class="column">
+            <h1 center centered-element>
               Card/Variant Unlock History
             </h1>
           </div>

--- a/generate_file.py
+++ b/generate_file.py
@@ -52,6 +52,7 @@ def addPlayerData(template_file):
     content = content.replace("{{ cardBacksOwned }}", str(data_parser.get_CardBacksOwned()))
     content = content.replace("{{ cardsOwned }}", str(data_parser.get_CardsOwned()))
     content = content.replace("{{ cardSplits }}", str(data_parser.get_CardSplits()))
+    content = content.replace("{{ cardSplitCounts }}", str(data_parser.get_CardSplitCounts()))
     content = content.replace("{{ variants }}", str(data_parser.get_Variants()))
     content = content.replace("{{ cardUnlockHistory }}", str(data_parser.get_CardUnlockHistory()))
     content = content.replace("{{ screenWidthPrct }}", screenWidthPrct)


### PR DESCRIPTION
This PR adds a feature i've been hungry for. In the "Collection" tab, it now includes a list of all card and how many splits you have of them. I'm working towards having every single card split so I've got more flexibility on my custom cards. 

<img src="https://github.com/jlamson/Snap_Player_Stats/assets/799143/3f18cfe1-1e3c-4d94-b3f2-a72d264c4795" w=500 />

**_{ ... more list omitted ... }_**
<img src="https://github.com/jlamson/Snap_Player_Stats/assets/799143/b69a29a9-5e47-43ef-8447-4fad49cdab00" w=500 />
