### PR TITLE
Prev & Next Navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,9 @@ cython_debug/
 
 # Project specific
 **stats**.html
+output/*.js
+output/*.html
 test_data/*.json
+
+# Mac
+.DS_Store

--- a/assets/template.html
+++ b/assets/template.html
@@ -65,7 +65,7 @@
 
       .body {
         background-color: dimgray;
-        background-image: url("assets/images/background.jpg");
+        background-image: url("../assets/images/background.jpg");
         font-size: 1.2vw;
       }
 

--- a/assets/template.html
+++ b/assets/template.html
@@ -26,6 +26,53 @@
         evt.currentTarget.className += " active";
       }
     </script>
+    <script src="generated_files.js"></script>
+    <script>
+      const updateLink = (linkElement, filename) => {
+        /*
+          Don't update visibility. I had previously hidden links w/ bad links,
+          but it un-centered the date row.Instead, we update the href attribute
+          to the filename if it exists, otherwise the link will just be
+          inavtive.
+        */
+        if (filename) {
+          linkElement.href = filename;
+        }
+      };
+      const setupNavigationLinks = () => {
+        /*
+          This script will setup the previous and next links based on the
+          current file, and the list of files retrieved from generated_files.js.
+          If this file doesn't exist in the list, or if it's the first or last
+          file, the links will be hidden as appropriate.
+        */
+        const currentFilename = window.location.pathname.split("/").pop();
+
+        const previousLink = document.getElementById("previous");
+        const nextLink = document.getElementById("next");
+
+        const currentFileIndex = generatedFiles.indexOf(currentFilename);
+        if (currentFileIndex < 0) {
+          previousLink.style.display = "none";
+          nextLink.style.display = "none";
+          return;
+        } else {
+          previousLink.style.display = "block";
+          nextLink.style.display = "block";
+        }
+
+        const previousFile =
+          currentFileIndex > 0 ? generatedFiles[currentFileIndex - 1] : null;
+        updateLink(previousLink, previousFile);
+
+        const nextFile =
+          currentFileIndex < generatedFiles.length - 1
+            ? generatedFiles[currentFileIndex + 1]
+            : null;
+        updateLink(nextLink, nextFile);
+      };
+      document.addEventListener("DOMContentLoaded", setupNavigationLinks);
+    </script>
     <style>
       @media screen and (max-width: 320px) {
         .center {
@@ -67,6 +114,18 @@
         background-color: dimgray;
         background-image: url("../assets/images/background.jpg");
         font-size: 1.2vw;
+      }
+
+      /* Flexbox styled w/ date in center, and adjacent prev & next links */
+      .date_row {
+        display: flex;
+        justify-content: space-between;
+        flex-flow: row nowrap;
+        align-items: center;
+        padding-top: 0.6%;
+        padding-bottom: 0.6%;
+        padding-inline-start: 0.6%;
+        padding-inline-end: 0.6%;
       }
 
       /* Style the tab */
@@ -219,10 +278,10 @@
             <h1 center>Conquest</h1>
           </button>
         </div>
-        <div>
-          <h3 class="center" style="margin-top: 0.6%; margin-bottom: 0.6%">
-            Last Update:{{ timeUpdated }}
-          </h3>
+        <div class="date_row">
+          <a id="previous">&lt; Previous</a>
+          <h3>Last Update:{{ timeUpdated }}</h3>
+          <a id="next">Next &gt;</a>
         </div>
       </div>
 

--- a/generate_file.py
+++ b/generate_file.py
@@ -1,3 +1,4 @@
+import json
 import os
 import webbrowser
 import assets.data_parser as data_parser
@@ -76,12 +77,24 @@ def openFileInBrowser(fileName):
     else:
         print(f"File {fileName} generated in the project folder. Open it manually in your browser!")
 
+def updateGeneratedFileList():
+    def isOutputFile(f):
+        return f.startswith("stats_") and f.endswith(".html")
+    generatedFiles = [f for f in os.listdir("output") if (isOutputFile(f))]
+    generatedFiles.sort()
+
+    jsonFileList = json.dumps(generatedFiles, indent = 2)
+    js_content = f"const generatedFiles = {jsonFileList};"
+    with open("output/generated_files.js", "w") as f:
+        f.write(js_content)
+
 def main():
     if file_config.isHelp():
         print(file_config.USAGE)
         exit()
 
     fileName = writeTemplateFile()
+    updateGeneratedFileList()
     openFileInBrowser(fileName)
     
 if __name__ == "__main__":

--- a/generate_file.py
+++ b/generate_file.py
@@ -4,6 +4,9 @@ import assets.data_parser as data_parser
 import assets.file_config as file_config
 from datetime import datetime 
 
+OUTPUT_DIR = "output"
+DATE_FORMAT = "%Y%m%d-%H%M%S"
+
 content = ""
 
 def addPlayerData(template_file):
@@ -52,8 +55,13 @@ def addPlayerData(template_file):
     content = content.replace("{{ cardUnlockHistory }}", str(data_parser.get_CardUnlockHistory()))
 
 def writeTemplateFile():
-    dateString = datetime.now().strftime("%d-%B-%Y-%H%M%S")
-    generatedFileName = f"stats_{dateString}.html"
+    if not os.path.exists(OUTPUT_DIR):
+        os.makedirs(OUTPUT_DIR)
+
+    # ex. stats_20210801-123456.html
+    # This format ensures that the files are sorted by date
+    dateString = datetime.now().strftime(DATE_FORMAT)
+    generatedFileName = f"{OUTPUT_DIR}/stats_{dateString}.html"
 
     with open("assets/template.html", encoding="utf-8-sig") as template_file:
         with open(generatedFileName, "w", encoding="utf-8") as generated_file:


### PR DESCRIPTION
* [Move generated files to output/. Update date format](https://github.com/jlamson/Snap_Player_Stats/commit/4deb5b61768c23308b684cfba54c53a5dac1ed6d)
* [Add file navigation between prev & next files](https://github.com/jlamson/Snap_Player_Stats/commit/7c235df577730dc01b6610ff376ae9e8eafc58ba) 
    * This was ChatGPTs suggestion. I thought it could be dynamic, but JS's access to your folder structure is pretty locked down. This approach builds the navigation in a way that each page will always get the latest generated list. As a cost though, any files added that were NOT generated w/ the script won't work (at least until you re-run the script)